### PR TITLE
fix: 长按无封面书籍时显示占位封面

### DIFF
--- a/app/src/main/java/com/huangder/lumibooks/ui/bookshelf/BookContextMenuOverlay.kt
+++ b/app/src/main/java/com/huangder/lumibooks/ui/bookshelf/BookContextMenuOverlay.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
@@ -164,12 +165,32 @@ private fun HighlightedCover(
             )
             .clip(RoundedCornerShape(AppRadius.sm))
     ) {
-        AsyncImage(
-            model = book.coverPath,
-            contentDescription = book.title,
-            modifier = Modifier.fillMaxSize(),
-            contentScale = ContentScale.Crop
-        )
+        if (book.coverPath != null) {
+            AsyncImage(
+                model = book.coverPath,
+                contentDescription = book.title,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(AppColors.BgGray),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = book.title.take(8),
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = AppColors.TextSecondary,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(8.dp),
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
HighlightedCover 中增加封面为空时的 fallback，与书库网格保持一致：灰色背景 + 书名文字。"