### PR TITLE
fix: TTS按钮大小统一 + TTS面板底部动效

### DIFF
--- a/app/src/main/java/com/huangder/lumibooks/ui/reader/PdfViewerScreen.kt
+++ b/app/src/main/java/com/huangder/lumibooks/ui/reader/PdfViewerScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -643,13 +645,22 @@ fun PdfViewerScreen(
                 modifier = Modifier.align(Alignment.BottomCenter)
             )
         }
+        val ttsBottomPadding by animateDpAsState(
+            targetValue = if (showMenu) 160.dp else 44.dp,
+            animationSpec = spring(dampingRatio = 0.82f, stiffness = 360f),
+            label = "ttsBottomPadding"
+        )
         AnimatedVisibility(
             visible = uiState.ttsActiveBookId == bookId &&
                 uiState.ttsPlaybackState != TtsPlaybackState.IDLE &&
                 !showPdfToc && conversionSheet == null,
             enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
             exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
-            modifier = Modifier.align(Alignment.BottomCenter)
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .navigationBarsPadding()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = ttsBottomPadding)
         ) {
             TtsPlayerPanel(
                 playbackState = uiState.ttsPlaybackState,
@@ -851,7 +862,7 @@ private fun PdfTopBar(
                 shape = CircleShape,
                 fallbackColor = AppColors.BgGray.copy(alpha = 0.8f),
                 contentScrimColor = glassContentScrimColor,
-                modifier = Modifier.size(48.dp),
+                modifier = Modifier.size(36.dp),
                 onClick = onTtsToggle,
                 contentAlignment = Alignment.Center
             ) {
@@ -859,7 +870,7 @@ private fun PdfTopBar(
                     Icons.Default.Headphones,
                     contentDescription = stringResource(R.string.tts_listen),
                     tint = if (isTtsActive) AppColors.Accent else AppColors.TextPrimary,
-                    modifier = Modifier.size(20.dp)
+                    modifier = Modifier.size(18.dp)
                 )
             }
             Spacer(Modifier.width(8.dp))

--- a/app/src/main/java/com/huangder/lumibooks/ui/reader/ReaderScreen.kt
+++ b/app/src/main/java/com/huangder/lumibooks/ui/reader/ReaderScreen.kt
@@ -1233,6 +1233,11 @@ fun ReaderScreen(bookId: String, onNavigateBack: () -> Unit, onPageReady: () -> 
                 }
             }
 
+            val ttsBottomPadding by animateDpAsState(
+                targetValue = if (uiState.isMenuVisible) 204.dp else 44.dp,
+                animationSpec = spring(dampingRatio = 0.82f, stiffness = 360f),
+                label = "ttsBottomPadding"
+            )
             AnimatedVisibility(
                 visible = uiState.ttsActiveBookId == uiState.book?.id &&
                     uiState.ttsPlaybackState != TtsPlaybackState.IDLE &&
@@ -1243,7 +1248,7 @@ fun ReaderScreen(bookId: String, onNavigateBack: () -> Unit, onPageReady: () -> 
                     .align(Alignment.BottomCenter)
                     .navigationBarsPadding()
                     .padding(horizontal = 24.dp)
-                    .padding(bottom = if (uiState.isMenuVisible) 204.dp else 44.dp)
+                    .padding(bottom = ttsBottomPadding)
             ) {
                 TtsPlayerPanel(
                     playbackState = uiState.ttsPlaybackState,


### PR DESCRIPTION
## 修复

### Bug 1: 液态玻璃下听书按键过大
PdfViewerScreen PdfTopBar 中 TTS 按钮容器 48dp→36dp，图标 20dp→18dp
与其他工具栏按钮（返回/书签等）统一。

### Bug 2:  TTS 控制栏位置错误与动画缺失
- PDF 阅读器：TTS 面板改为浮动样式（navigationBarsPadding + 24dp 边距 + 160dp/44dp 底部间距），菜单展开时自动上移不重叠
- EPUB 阅读器：底部 padding 改用 animateDpAsState，菜单展开/收起时面板平滑移动