### PR TITLE
docs: configure GitHub community and sponsorship entry

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+custom:
+  - https://huangder.top/sponsor.html

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
 custom:
   - https://huangder.top/sponsor.html
+  - https://paypal.me/Huangder

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 💬 使用问题 / 讨论
+  - name: 💬 反馈与求助 / Feedback & Help
     url: https://github.com/huangder/Lumi_Books/discussions
     about: |
-      使用上的疑问、功能想法交流，或者不确定是不是 bug 的问题，
-      请到 Discussions 发起讨论，不要提 Issue。
+      使用求助、普通体验反馈、功能想法，或不确定是否为 bug 的问题，
+      请到 Discussions 交流；已确认可稳定复现的程序错误请提交 Issue。
   - name: 📖 官网文档
     url: https://huangder.top
     about: 使用前请先查阅官网，了解功能特性与隐私政策。

--- a/README.en.md
+++ b/README.en.md
@@ -133,6 +133,14 @@ See [Changelog](https://huangder.top/changelog.html)
 
 ---
 
+## ❤️ Support Lumi
+
+Lumi will remain free, open source, and ad-free. If it has been useful to you, you can support its continued development through the [sponsorship page](https://huangder.top/sponsor.html).
+
+The **Sponsor** button in the GitHub repository sidebar will also list the available support options. Sponsorship is entirely optional and does not affect feature access or issue handling.
+
+---
+
 ## 📜 License
 
 Lumi's original code is open-sourced under the [MIT License](LICENSE). Third-party dependencies and adaptations follow their respective licenses. The Liquid Glass implementation is adapted from [AndroidLiquidGlass / Backdrop](https://github.com/Kyant0/AndroidLiquidGlass) under Apache 2.0. © 2026 Huangder

--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@
 
 ---
 
+## ❤️ 支持 Lumi
+
+Lumi 始终保持免费、开源且无广告。如果它对你有帮助，欢迎通过 [赞助页](https://huangder.top/sponsor.html) 请开发者喝杯咖啡。
+
+GitHub 页面右侧的 **Sponsor** 按钮也会提供可用的赞助入口。赞助完全自愿，不会影响功能使用或问题处理。
+
+---
+
 ## 📜 许可证
 
 Lumi 原创代码采用 [MIT License](LICENSE) 开源。第三方依赖及改编代码继续遵循各自许可证；其中液态玻璃使用并改编自 Apache 2.0 许可的 [AndroidLiquidGlass / Backdrop](https://github.com/Kyant0/AndroidLiquidGlass)。© 2026 Huangder


### PR DESCRIPTION
## Summary
- add GitHub's Sponsor funding entry for the existing Lumi sponsorship page
- add bilingual sponsorship guidance to the Chinese and English READMEs
- route usage questions and ordinary feedback to Discussions while keeping reproducible bugs in Issues

## Follow-up
- Add the final PayPal.Me URL to `.github/FUNDING.yml` once the public link is available.
- Configure the four Discussions categories and publish the bilingual welcome post after reviewing the repository settings.

## Validation
- `git diff --check`
- confirmed both existing public links return HTTP 200
- this branch starts from `origin/main` and contains no local development changes